### PR TITLE
Update mod to 1.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,29 @@
 plugins {
-	id 'fabric-loom' version '0.2.7-SNAPSHOT'
-	id 'maven-publish'
+	id 'fabric-loom' version '0.11-SNAPSHOT'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
-minecraft {
-}
-
 repositories {
-    jcenter()
+	jcenter()
+	maven {
+		name = "Fabric"
+		url = uri("https://maven.fabricmc.net/")
+	}
+	maven {
+		name = "Shedaniel Libs"
+		url = uri("https://maven.shedaniel.me/")
+	}
+	maven {
+		name = "TerraformersMC"
+		url = uri("https://maven.terraformersmc.com/")
+	}
+	mavenLocal()
 }
 
 dependencies {
@@ -22,73 +31,26 @@ dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	modImplementation "me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}"
 
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
-
-    // clothconfig
-    modApi "me.shedaniel.cloth:config-2:${project.clothconfig_version}"
-    include "me.shedaniel.cloth:config-2:${project.clothconfig_version}"
-
-    // autoconfig
-    modApi "me.sargunvohra.mcmods:autoconfig1u:${project.autoconfig_version}" // to use in dev
-    include "me.sargunvohra.mcmods:autoconfig1u:${project.autoconfig_version}" // to include into mod jar
-
-    // modmenu integration
-    modImplementation "io.github.prospector:modmenu:${project.modmenu_version}"
+	// Optional mod menu support
+	modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
 }
 
 processResources {
 	inputs.property "version", project.version
 
-	from(sourceSets.main.resources.srcDirs) {
-		include "fabric.mod.json"
+	filesMatching("fabric.mod.json") {
 		expand "version": project.version
 	}
-
-	from(sourceSets.main.resources.srcDirs) {
-		exclude "fabric.mod.json"
-	}
 }
 
-// ensure that the encoding is set to UTF-8, no matter what the system default is
-// this fixes some edge cases with special characters not displaying correctly
-// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-tasks.withType(JavaCompile) {
-	options.encoding = "UTF-8"
-}
-
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-	classifier = "sources"
-	from sourceSets.main.allSource
+tasks.withType(JavaCompile).configureEach {
+	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
+	it.options.release = 17
 }
 
 jar {
 	from "LICENSE"
 }
-
-// configure the maven publication
-//publishing {
-//	publications {
-//		mavenJava(MavenPublication) {
-//			// add all the jars that should be included when publishing to maven
-//			artifact(jar) {
-//				builtBy remapJar
-//			}
-//			artifact("${project.buildDir.absolutePath}/libs/${archivesBaseName}-${project.version}.jar"){
-//				builtBy remapJar
-//			}
-//			artifact(sourcesJar) {
-//				builtBy remapSourcesJar
-//			}
-//		}
-//	}
-//
-//	// select the repositories you want to publish to
-//	repositories {
-//		// uncomment to publish to the local maven
-//		// mavenLocal()
-//	}
-//}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,18 @@
 org.gradle.jvmargs  = -Xmx1G
 
 #Fabric properties
-minecraft_version   = 1.16.1
-yarn_mappings       = 1.16.1+build.4
-loader_version      = 0.8.8+build.202
+minecraft_version   = 1.18.2
+yarn_mappings       = 1.18.2+build.2
+loader_version      = 0.13.3
+
+fabric_version      = 0.48.0+1.18.2
+loom_version        = 0.11-SNAPSHOT
 
 #Mod properties
-mod_version         = 1.0.1
+mod_version         = 1.1.0
 maven_group         = matjojo.main
 archives_base_name  = fastestf
 
 #Dependencies
-fabric_api_version  = 0.13.1+build.370-1.16
-autoconfig_version  = 3.2.0-unstable
-modmenu_version     = 1.12.1+build.15
-clothconfig_version = 4.5.6
+cloth_version       = 6.2.57
+modmenu_version     = 3.1.0

--- a/src/main/java/matjojo/client/FConfig.java
+++ b/src/main/java/matjojo/client/FConfig.java
@@ -1,8 +1,8 @@
 package matjojo.client;
 
-import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
-import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
-import me.sargunvohra.mcmods.autoconfig1u.annotation.ConfigEntry;
+import me.shedaniel.autoconfig.ConfigData;
+import me.shedaniel.autoconfig.annotation.Config;
+import me.shedaniel.autoconfig.annotation.ConfigEntry;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/matjojo/client/FModmenuIntegration.java
+++ b/src/main/java/matjojo/client/FModmenuIntegration.java
@@ -1,11 +1,10 @@
 package matjojo.client;
 
-import io.github.prospector.modmenu.api.ConfigScreenFactory;
-import io.github.prospector.modmenu.api.ModMenuApi;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+import me.shedaniel.autoconfig.AutoConfig;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-
 
 @Environment(EnvType.CLIENT)
 public class FModmenuIntegration implements ModMenuApi {

--- a/src/main/java/matjojo/client/main.java
+++ b/src/main/java/matjojo/client/main.java
@@ -1,7 +1,7 @@
 package matjojo.client;
 
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
-import me.sargunvohra.mcmods.autoconfig1u.serializer.GsonConfigSerializer;
+import me.shedaniel.autoconfig.AutoConfig;
+import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;

--- a/src/main/java/matjojo/client/mixin/detectOtherPlayerDeathChatHudListenerMixin.java
+++ b/src/main/java/matjojo/client/mixin/detectOtherPlayerDeathChatHudListenerMixin.java
@@ -4,7 +4,7 @@ import matjojo.client.util;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.hud.ChatListenerHud;
+import net.minecraft.client.gui.hud.ChatHudListener;
 import net.minecraft.network.MessageType;
 import net.minecraft.network.packet.c2s.play.ChatMessageC2SPacket;
 import net.minecraft.text.Text;
@@ -17,13 +17,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import java.util.UUID;
 
 
-@Mixin(ChatListenerHud.class)
-public abstract class detectOtherPlayerDeathChatListenerHudMixin {
+@Mixin(ChatHudListener.class)
+public abstract class detectOtherPlayerDeathChatHudListenerMixin {
 
 	@Environment(EnvType.CLIENT)
 	@Inject(method = "onChatMessage(Lnet/minecraft/network/MessageType;Lnet/minecraft/text/Text;Ljava/util/UUID;)V",
 	at = @At(value = "HEAD"))
-	private void onChatMessageMixin(MessageType type, Text text, UUID id, CallbackInfo ci) {
+	private void onChatMessage(MessageType type, Text text, UUID id, CallbackInfo ci) {
 		if (!util.isUsableDeathMessage(type, text)) {
 			return;
 		}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -7,7 +7,7 @@
   "authors": [
     "Matjojo"
   ],
-  "contributors": [],
+  "contributors": ["MattElek"],
   "contact": {
     "homepage": "https://github.com/matjojo/fastestf",
     "sources": "https://github.com/matjojo/fastestf",
@@ -16,11 +16,9 @@
   "icon": "assets/fastestf/icon.png",
   "environment": "client",
   "entrypoints": {
-    "main": [],
     "client": [
       "matjojo.client.main"
     ],
-    "server": [],
     "modmenu": [
       "matjojo.client.FModmenuIntegration"
     ]
@@ -29,7 +27,10 @@
     "fastestf.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.4.0",
-    "minecraft": ">=1.16.0"
+    "fabricloader": ">=0.13.3",
+    "fabric": "*",
+    "cloth-config": "*",
+    "minecraft": ">=1.18.2",
+    "java": ">=17"
   }
 }

--- a/src/main/resources/fastestf.mixins.json
+++ b/src/main/resources/fastestf.mixins.json
@@ -1,13 +1,11 @@
 {
   "required": true,
   "package": "matjojo.client.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [],
   "client": [
-    "detectOtherPlayerDeathChatListenerHudMixin"
+    "detectOtherPlayerDeathChatHudListenerMixin"
   ],
-
-  "server": [],
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
Updated mod and dependencies for 1.18.2

While the mod works on newer versions, it throws an error on startup, and doesn't work with modmenu. I wanted to fix the error messages thrown on startup, and fix the modmenu config issue.

Notable changes:
Follow fabric and rename the mixin from ChatListenerHud to ChatHudListener, allowing successful building.
Update autoconfig1u to cloth-config
Update modmenu implementation.

Additionally, I updated various build settings and updated basically all of the dependencies.

Notably, I replaced [autoconfig1u](https://www.curseforge.com/minecraft/mc-mods/auto-config-updated-api) with cloth-config, which now bundles autoconfig. This fixes an error thrown on startup with newer MC versions. While it's possible to continue using autoconfig1u, that behavior isn't recommended and likely will cause breakage in the future. Hopefully, this will help future-proof the mod so it continues working, and additionally fixes the error message thrown on startup in 1.18.2. Note, this does have the effect of adding Cloth Config as a dependency, as it's not recommended to compile the mod with it included.